### PR TITLE
Improve gate service concurrency handling

### DIFF
--- a/src/service_gate/service_gate.go
+++ b/src/service_gate/service_gate.go
@@ -3,7 +3,6 @@ package service_gate
 import (
 	"net"
 	"strings"
-	"sync"
 
 	"GoGameServer/src/codec"
 	"GoGameServer/src/global"
@@ -20,7 +19,6 @@ import (
 type ServiceGate struct {
 	err      error
 	workPool *ants.Pool
-	wg       sync.WaitGroup
 	*service_common.ServerCommon
 	gsConn    net.Conn
 	proxyLi   net.Listener
@@ -32,15 +30,16 @@ type ServiceGate struct {
 }
 
 func NewServiceGate(_name string, id int) *ServiceGate {
-	pool, err := ants.NewPool(ants.DefaultAntsPoolSize)
+	pool, err := ants.NewPool(global.DefaultPoolSize)
 	lib.SysLoggerFatal(err, "New Gate pool error")
 	return &ServiceGate{
 		workPool: pool,
-		wg:       sync.WaitGroup{},
 		ServerCommon: &service_common.ServerCommon{
-			Name: _name,
-			Id:   id,
+			Name:      _name,
+			Id:        id,
+			CloseChan: make(chan int, 1),
 		},
+		runChan:     make(chan bool, 1),
 		msgChan:     make(chan pb.ProtoInternal, lib.MaxMessageCount),
 		EventServer: new(gnet.EventServer),
 	}
@@ -100,74 +99,71 @@ func (s *ServiceGate) Start() (err error) {
 
 func (s *ServiceGate) React(frame []byte, c gnet.Conn) (out []byte, action gnet.Action) {
 	var err error
-	if s.workPool == nil {
-		s.workPool, err = ants.NewPool(global.DefaultPoolSize)
-		lib.LogErrorAndReturn(err, "service gate new pool error")
-	}
-	if s.workPool != nil && err == nil {
-		s.wg.Add(1)
-		go func() {
-			err := s.workPool.Submit(func() {
-				// session := lib.NewSession(c)
-				// headReader := lib.NewMessageHeadReader()
-				// headReader.Head.Decode(frame)
-				// if headReader.Head.Check() != nil {
-				//	return
-				// }
-				// headReader.ReadMessage(frame[headReader.Head.HeaderLength:])
-				// switch headReader.Head.Command {
-				// case lib.NetMsgToGame:
-				//	s.SendToGame(headReader.Data)
-				// case lib.NetMsgToLogin:
-				//	s.SendToLogin(headReader.Data)
-				// case lib.NetMsgToDB:
-				//	s.SendToDB(headReader.Data)
-				// default:
-				//	return
-				// }
+	if s.workPool != nil {
+		err = s.workPool.Submit(func() {
+			// session := lib.NewSession(c)
+			// headReader := lib.NewMessageHeadReader()
+			// headReader.Head.Decode(frame)
+			// if headReader.Head.Check() != nil {
+			//	return
+			// }
+			// headReader.ReadMessage(frame[headReader.Head.HeaderLength:])
+			// switch headReader.Head.Command {
+			// case lib.NetMsgToGame:
+			//	s.SendToGame(headReader.Data)
+			// case lib.NetMsgToLogin:
+			//	s.SendToLogin(headReader.Data)
+			// case lib.NetMsgToDB:
+			//	s.SendToDB(headReader.Data)
+			// default:
+			//	return
+			// }
 
-				/*
-					//var message proto.Message
-					msg := &pb.Person1{}
-					err := proto.Unmarshal(frame, msg)
-					lib.LogIfError(err, "unmarshal message error")
-					if !s.h.Check(msg) {
-						return
-					}
-					lib.SugarLogger.Info(msg.Id)
-					lib.SugarLogger.Info(msg.Name)
-					lib.SugarLogger.Info(msg.Email)
-				*/
-
-				msg := &pb.ProtoInternal{}
-				err = proto.Unmarshal(frame, msg)
-				lib.LogErrorAndReturn(err, "")
-				if msg.Dst != s.Name {
-					switch msg.Cmd {
-					case pb.InternalGateToProxy:
-						if strings.Contains(msg.Dst, "proxy") {
-							s.SendToProxy(frame)
-						}
-					case pb.InternalProxyToGate:
-						s.msgChan <- *msg
-					}
+			/*
+				//var message proto.Message
+				msg := &pb.Person1{}
+				err := proto.Unmarshal(frame, msg)
+				lib.LogIfError(err, "unmarshal message error")
+				if !s.h.Check(msg) {
+					return
 				}
-			})
-			if err != nil {
-				lib.Log(zap.ErrorLevel, "submit message pool error", err)
+				lib.SugarLogger.Info(msg.Id)
+				lib.SugarLogger.Info(msg.Name)
+				lib.SugarLogger.Info(msg.Email)
+			*/
+
+			msg := &pb.ProtoInternal{}
+			err = proto.Unmarshal(frame, msg)
+			lib.LogErrorAndReturn(err, "")
+			if msg.Dst != s.Name {
+				switch msg.Cmd {
+				case pb.InternalGateToProxy:
+					if strings.Contains(msg.Dst, "proxy") {
+						s.SendToProxy(frame)
+					}
+				case pb.InternalProxyToGate:
+					s.msgChan <- *msg
+				}
 			}
-			s.wg.Done()
-		}()
-		s.wg.Wait()
+		})
+		if err != nil {
+			lib.Log(zap.ErrorLevel, "submit message pool error", err)
+		}
 	}
 	return
 }
 
 func (s *ServiceGate) Stop() {
-	defer func() {
+	if s.CloseChan != nil {
+		select {
+		case <-s.CloseChan:
+		default:
+			close(s.CloseChan)
+		}
+	}
+	if s.workPool != nil {
 		s.workPool.Release()
-	}()
-	s.wg.Wait()
+	}
 }
 
 func (s *ServiceGate) Run() {
@@ -179,7 +175,7 @@ func (s *ServiceGate) Run() {
 			lib.SugarLogger.Info("running")
 		case <-s.CloseChan:
 			close(s.runChan)
-			close(s.CloseChan)
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- initialize gate control channels and worker pool up front to avoid nil panics
- remove per-message waitgroup blocking in the gnet React path to keep event handling asynchronous
- handle shutdown signals safely by closing channels once and exiting the run loop cleanly

## Testing
- go test ./... *(hangs in environment; interrupted with Ctrl+C)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e4ad78cc833285e3d4c77be6a0ad)